### PR TITLE
fix: LlamaRelativeQuorum contract name in factory invariant test

### DIFF
--- a/test/invariants/LlamaFactory.invariants.t.sol
+++ b/test/invariants/LlamaFactory.invariants.t.sol
@@ -129,7 +129,7 @@ contract LlamaFactoryInvariants is LlamaTestSetup {
     excludeArtifact("LlamaCore");
     excludeArtifact("LlamaExecutor");
     excludeArtifact("LlamaPolicy");
-    excludeArtifact("RelativeQuorum");
+    excludeArtifact("LlamaRelativeQuorum");
 
     bytes4[] memory selectors = new bytes4[](2);
     selectors[0] = handler.llamaFactory_deploy.selector;


### PR DESCRIPTION
**Motivation:**
The following error/warning was appearing in the middle of forge tests. It didn't break any test, but we need to fix it. 

```
ERROR forge::multi_runner: error=RelativeQuorum not found in the project. Allowed format: `contract_name` or `contract_path:contract_name`.
```

**Modifications:**

`RelativeQuorum` -> `LlamaRelativeQuorum` in factory invariant test

**Result:**

The above error/warning no longer appears in the middle of forge tests